### PR TITLE
Fix Tag Order for _base.tpl

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -3,9 +3,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -84,6 +84,7 @@ var GoroGenerator = yeoman.generators.Base.extend({
       this.projectPath = props.projectPath;
       this.projectBranch = props.projectBranch;
       this.goroPath = props.goroPath;
+      this.projectFullPath = this.projectDomain + this.projectPath;
 
       done();
     }.bind(this));
@@ -96,33 +97,33 @@ var GoroGenerator = yeoman.generators.Base.extend({
 
   writing: function() {
       // Set up directory structure
-      this.mkdir('css');
-      this.mkdir('css/components');
-      this.mkdir('index.html_data');
-      this.mkdir('js');
-      this.mkdir('js/components');
-      this.mkdir('js/components/my-component');
-      this.mkdir('js/sections');
+      this.mkdir(this.projectFullPath + 'css');
+      this.mkdir(this.projectFullPath + 'css/components');
+      this.mkdir(this.projectFullPath + 'index.html_data');
+      this.mkdir(this.projectFullPath + 'js');
+      this.mkdir(this.projectFullPath + 'js/components');
+      this.mkdir(this.projectFullPath + 'js/components/my-component');
+      this.mkdir(this.projectFullPath + 'js/sections');
 
       // Process templates
       this.template('_gruntfile.js', 'gruntfile.js');
-      this.template('_base.tpl', 'base.tpl');
-      this.template('_index.html', 'index.html');
-      this.template('js/_main.js', 'js/main.js');
-      this.template('js/_main.min.js', 'js/main.min.js');
-      this.template('js/_app.js', 'js/app.js');
-      this.template('js/_my-service.js', 'js/my-service.js');
-      this.template('js/sections/_home-controller.js', 'js/sections/home-controller.js');
-      this.template('js/components/my-component/_my-component-controller.js', 'js/components/my-component/my-component-controller.js');
-      this.template('js/components/my-component/_my-component-directive.js', 'js/components/my-component/my-component-directive.js');
+      this.template('_base.tpl', this.projectFullPath + 'base.tpl');
+      this.template('_index.html', this.projectFullPath + 'index.html');
+      this.template('js/_main.js', this.projectFullPath + 'js/main.js');
+      this.template('js/_main.min.js', this.projectFullPath + 'js/main.min.js');
+      this.template('js/_app.js', this.projectFullPath + 'js/app.js');
+      this.template('js/_my-service.js', this.projectFullPath + 'js/my-service.js');
+      this.template('js/sections/_home-controller.js', this.projectFullPath + 'js/sections/home-controller.js');
+      this.template('js/components/my-component/_my-component-controller.js', this.projectFullPath + 'js/components/my-component/my-component-controller.js');
+      this.template('js/components/my-component/_my-component-directive.js', this.projectFullPath + 'js/components/my-component/my-component-directive.js');
 
       // Copy non-template files
       this.src.copy('package.json', 'package.json');
-      this.src.copy('config.inc.tpl', 'config.inc.tpl');
-      this.src.copy('css/default.min.css', 'css/default.min.css');
-      this.src.copy('css/components/my-component.scss', 'css/components/my-component.scss');
-      this.src.copy('index.html_data/side-content.gnode', 'index.html_data/side-content.gnode');
-      this.src.copy('js/components/my-component/my-directive-template.html', 'js/components/my-component/my-directive-template.html');
+      this.src.copy('config.inc.tpl', this.projectFullPath + 'config.inc.tpl');
+      this.src.copy('css/default.min.css', this.projectFullPath + 'css/default.min.css');
+      this.src.copy('css/components/my-component.scss', this.projectFullPath + 'css/components/my-component.scss');
+      this.src.copy('index.html_data/side-content.gnode', this.projectFullPath + 'index.html_data/side-content.gnode');
+      this.src.copy('js/components/my-component/my-directive-template.html', this.projectFullPath + 'js/components/my-component/my-directive-template.html');
   },
 
   install: function () {

--- a/app/index.js
+++ b/app/index.js
@@ -107,23 +107,23 @@ var GoroGenerator = yeoman.generators.Base.extend({
 
       // Process templates
       this.template('_gruntfile.js', 'gruntfile.js');
-      this.template('_base.tpl', 'base.tpl');
-      this.template('_index.html', 'index.html');
-      this.template('js/_main.js', 'js/main.js');
-      this.template('js/_main.min.js', 'js/main.min.js');
-      this.template('js/_app.js', 'js/app.js');
-      this.template('js/_my-service.js', 'js/my-service.js');
-      this.template('js/sections/_home-controller.js', 'js/sections/home-controller.js');
-      this.template('js/components/my-component/_my-component-controller.js', 'js/components/my-component/my-component-controller.js');
-      this.template('js/components/my-component/_my-component-directive.js', 'js/components/my-component/my-component-directive.js');
-      this.template('css/_default.min.css', 'css/default.min.css');
+      this.template('_base.tpl', this.projectFullPath + 'base.tpl');
+      this.template('_index.html', this.projectFullPath + 'index.html');
+      this.template('js/_main.js', this.projectFullPath + 'js/main.js');
+      this.template('js/_main.min.js', this.projectFullPath + 'js/main.min.js');
+      this.template('js/_app.js', this.projectFullPath + 'js/app.js');
+      this.template('js/_my-service.js', this.projectFullPath + 'js/my-service.js');
+      this.template('js/sections/_home-controller.js', this.projectFullPath + 'js/sections/home-controller.js');
+      this.template('js/components/my-component/_my-component-controller.js', this.projectFullPath + 'js/components/my-component/my-component-controller.js');
+      this.template('js/components/my-component/_my-component-directive.js', this.projectFullPath + 'js/components/my-component/my-component-directive.js');
+      this.template('css/_default.min.css', this.projectFullPath + 'css/default.min.css');
 
       // Copy non-template files
       this.src.copy('package.json', 'package.json');
-      this.src.copy('config.inc.tpl', 'config.inc.tpl');
-      this.src.copy('css/components/my-component.scss', 'css/components/my-component.scss');
-      this.src.copy('index.html_data/side-content.gnode', 'index.html_data/side-content.gnode');
-      this.src.copy('js/components/my-component/my-directive-template.html', 'js/components/my-component/my-directive-template.html');
+      this.src.copy('config.inc.tpl', this.projectFullPath + 'config.inc.tpl');
+      this.src.copy('css/components/my-component.scss', this.projectFullPath + 'css/components/my-component.scss');
+      this.src.copy('index.html_data/side-content.gnode', this.projectFullPath + 'index.html_data/side-content.gnode');
+      this.src.copy('js/components/my-component/my-directive-template.html', this.projectFullPath + 'js/components/my-component/my-directive-template.html');
   },
 
   install: function () {


### PR DESCRIPTION
I noticed that the generated projects fail because the initial extends tag was underneath the comments tag. Not sure if there was eventually going to be a task to remove the comment block, but for now I've got it working just by putting the extend before the comment tag.

Please review.
