### PR TITLE
Fix css bug. Make glue version a config variable in js/scss.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -115,11 +115,11 @@ var GoroGenerator = yeoman.generators.Base.extend({
       this.template('js/sections/_home-controller.js', 'js/sections/home-controller.js');
       this.template('js/components/my-component/_my-component-controller.js', 'js/components/my-component/my-component-controller.js');
       this.template('js/components/my-component/_my-component-directive.js', 'js/components/my-component/my-component-directive.js');
+      this.template('css/_default.min.css', 'css/default.min.css');
 
       // Copy non-template files
       this.src.copy('package.json', 'package.json');
       this.src.copy('config.inc.tpl', 'config.inc.tpl');
-      this.src.copy('css/default.min.css', 'css/default.min.css');
       this.src.copy('css/components/my-component.scss', 'css/components/my-component.scss');
       this.src.copy('index.html_data/side-content.gnode', 'index.html_data/side-content.gnode');
       this.src.copy('js/components/my-component/my-directive-template.html', 'js/components/my-component/my-directive-template.html');

--- a/app/templates/config.inc.tpl
+++ b/app/templates/config.inc.tpl
@@ -17,6 +17,7 @@ limitations under the License.
 {# ------- Global Variables --------- #}
 {% var as app_domain %}"{{goro.page.site.domain}}"{% endvar %}
 {% var as app_path %}"{{goro.page.path_relative}}"{% endvar %}
+{% var as glue_version %}"v2_4"{% endvar %}
 
 {# ------- Datasources -------------- #}
 {% var as boilerplate_db %}

--- a/app/templates/css/_default.min.css
+++ b/app/templates/css/_default.min.css
@@ -28,14 +28,35 @@ limitations under the License.
 
     {% site "glue-boilerplate-angular" %}
 
+    {% include "<%= projectDomain %><%= projectPath %>config.inc.tpl" %}
+
     @import url(//www.google.com/css/maia.css);
 
+    {% comment %}
+      This is the glue scss package loader for web standard/Maia. It doesn't
+      support components other than pagination. If you'd like base skins for
+      glue components, use the base skin loader shown further down.
+    {% endcomment %}
     {% var as glue_scss_config %}{
       "components": [
         "pagination"
       ]
     }{% endvar %}
-    {% include "glue/scss/webstandard/package.scss.inc.tpl" with glue_scss_config=glue_scss_config %}
+    {% var as glue_css_package %}"glue/releases/{{glue_version}}/scss/webstandard/package.scss.inc.tpl"{% endvar %}
+    {% include glue_css_package with glue_scss_config=glue_scss_config %}
+
+    {% comment %}
+      This loads basic skins for glue components. Many components are supported.
+      The skins are very simple and you'd be expected to customize them.
+      Separate each component name with a comma in the scss_glue_components
+      variable.
+    {% endcomment %}
+    {% var as glue_css_base_macro %}"glue/releases/{{glue_version}}/scss/package.scss.inc.tpl"{% endvar %}
+    {% include glue_css_base_macro %}
+    {% var as scss_glue_components %}[
+      "show"
+    ]{% endvar %}
+    {% render glue_scss with components=scss_glue_components %}
 
     {% include "glue/boilerplate/angular/css/components/my-component.scss" %}
 

--- a/app/templates/js/_main.min.js
+++ b/app/templates/js/_main.min.js
@@ -15,7 +15,7 @@
 
 {% site "glue-boilerplate-angular" %}
 
-{% var as glue_version %}"latest"{% endvar %}
+{% include "<%= projectDomain %><%= projectPath %>config.inc.tpl" %}
 
 {% if request.GET.js_debug|add:"0" %}
 


### PR DESCRIPTION
Fix css bug. Scaffold was mixing glue versions between js and sass causing the left pagination button from displaying correctly. Also added base skin boilerplate for glue and noted limits of web standard skin support.
